### PR TITLE
fix: use correct `lockReleasePoint` type

### DIFF
--- a/src/libs/seed_liquidity_utils.ts
+++ b/src/libs/seed_liquidity_utils.ts
@@ -562,7 +562,7 @@ export async function createSeedLiquidityLfgInstructions(
   poolAddress: PublicKey,
   payer: PublicKey,
   base: PublicKey,
-  lockReleasePoint: PublicKey,
+  lockReleasePoint: BN,
   seedAmount: BN,
   curvature: number,
   minPricePerLamport: BN,


### PR DESCRIPTION
Previously was `PublicKey` type when all other uses have `BN` type.